### PR TITLE
emms-player-mpv.el

### DIFF
--- a/emms-player-mpv.el
+++ b/emms-player-mpv.el
@@ -44,7 +44,7 @@
            "mov" "avi" "divx" "ogm" "ogv" "asf" "mkv"
            "rm" "rmvb" "mp4" "flac" "vob" "m4a" "ape"
            "flv" "webm"))
-  "mpv" "--quiet" "--really-quiet")
+  "mpv" "--quiet" "--really-quiet" "--no-video" "--vo=null")
 
 (defadvice emms-player-mpv-start (around append-arguments activate)
   (unless (file-exists-p emms-mpv-input-file)


### PR DESCRIPTION
Prevent mpv from opening gui windows.

If a music file contains an embedded cover art mpv opens a gui window.  Prevent it.